### PR TITLE
Fix all map pin coordinates (#12)

### DIFF
--- a/src/lib/components/LeafletMap.svelte
+++ b/src/lib/components/LeafletMap.svelte
@@ -17,7 +17,7 @@
 		height?: string;
 	}
 
-	let { markers, center = [49.1264, -1.0986], zoom = 10, height = '500px' }: Props = $props();
+	let { markers, center = [49.1728, -0.9887], zoom = 10, height = '500px' }: Props = $props();
 
 	let mapContainer: HTMLDivElement;
 

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -85,9 +85,9 @@
 		<div class="map-wrapper">
 			<LeafletMap
 				markers={[
-					{ lat: 49.1264, lng: -1.0986, title: 'Marianne Cottage', description: '1 La Haye, 50680 Couvains, France', type: 'cottage' }
+					{ lat: 49.1728, lng: -0.9887, title: 'Marianne Cottage', description: '1 La Haye, 50680 Couvains, France', type: 'cottage' }
 				]}
-				center={[49.1264, -1.0986]}
+				center={[49.1728, -0.9887]}
 				zoom={13}
 				height="400px"
 			/>

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -8,15 +8,15 @@
 	const { messages } = data;
 
 	const mapMarkers = [
-		{ lat: 49.1264, lng: -1.0986, title: 'Marianne Cottage', description: 'Your base in Normandy', type: 'cottage' as const },
-		{ lat: 49.3697, lng: -0.8642, title: 'Omaha Beach', description: 'Historic D-Day landing site, 29 km', type: 'ww2' as const },
-		{ lat: 49.3467, lng: -0.9167, title: 'La Cambe German Cemetery', description: 'WW2 memorial, 26 km', type: 'ww2' as const },
-		{ lat: 49.355, lng: -0.9083, title: 'Overlord Museum', description: 'D-Day history museum, 29 km', type: 'ww2' as const },
-		{ lat: 49.145, lng: -1.1267, title: '29th Division Monument', description: 'American WW2 memorial, 4.3 km', type: 'ww2' as const },
-		{ lat: 49.1886, lng: -1.0345, title: 'Cerisy Abbey', description: 'Medieval abbey in countryside, 5 km', type: 'nature' as const },
-		{ lat: 49.1117, lng: -1.0881, title: 'Haras National de Saint-Lô', description: 'Historic stud farm, 13 km', type: 'nature' as const },
-		{ lat: 49.1117, lng: -1.0881, title: 'Saint-Lô', description: 'Historic town, 13 km', type: 'towns' as const },
-		{ lat: 49.2742, lng: -0.7034, title: 'Bayeux', description: 'Medieval town with cathedral, 30 km', type: 'towns' as const }
+		{ lat: 49.1728, lng: -0.9887, title: 'Marianne Cottage', description: 'Your base in Normandy', type: 'cottage' as const },
+		{ lat: 49.3715, lng: -0.8885, title: 'Omaha Beach', description: 'Historic D-Day landing site, 29 km', type: 'ww2' as const },
+		{ lat: 49.3432, lng: -1.0266, title: 'La Cambe German Cemetery', description: 'WW2 memorial, 26 km', type: 'ww2' as const },
+		{ lat: 49.3479, lng: -0.8558, title: 'Overlord Museum', description: 'D-Day history museum, 29 km', type: 'ww2' as const },
+		{ lat: 49.2041, lng: -1.0245, title: '29th Division Monument', description: 'American WW2 memorial, 4.3 km', type: 'ww2' as const },
+		{ lat: 49.1950, lng: -0.9370, title: 'Cerisy Abbey', description: 'Medieval abbey in countryside, 5 km', type: 'nature' as const },
+		{ lat: 49.1197, lng: -1.0786, title: 'Haras National de Saint-Lô', description: 'Historic stud farm, 13 km', type: 'nature' as const },
+		{ lat: 49.1155, lng: -1.0828, title: 'Saint-Lô', description: 'Historic town, 13 km', type: 'towns' as const },
+		{ lat: 49.2764, lng: -0.7031, title: 'Bayeux', description: 'Medieval town with cathedral, 30 km', type: 'towns' as const }
 	];
 
 	const attractions = [


### PR DESCRIPTION
## Summary
- Corrected GPS coordinates for all 9 map pins (cottage, attractions, towns) on explore and contact pages
- Updated LeafletMap default center to match corrected cottage location
- Every pin was placed at an incorrect location; verified correct coords via multiple geo sources

## Corrections
| Location | Old | New |
|---|---|---|
| Marianne Cottage | 49.1264, -1.0986 | 49.1728, -0.9887 |
| Omaha Beach | 49.3697, -0.8642 | 49.3715, -0.8885 |
| La Cambe Cemetery | 49.3467, -0.9167 | 49.3432, -1.0266 |
| Overlord Museum | 49.355, -0.9083 | 49.3479, -0.8558 |
| 29th Division Monument | 49.145, -1.1267 | 49.2041, -1.0245 |
| Cerisy Abbey | 49.1886, -1.0345 | 49.1950, -0.9370 |
| Haras National | 49.1117, -1.0881 | 49.1197, -1.0786 |
| Saint-Lô | 49.1117, -1.0881 | 49.1155, -1.0828 |
| Bayeux | 49.2742, -0.7034 | 49.2764, -0.7031 |

## Test plan
- [x] All 72 tests pass
- [ ] Visual check: pins render at correct locations on map

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)