### PR TITLE
Remove Quick Links from footer (#9)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -306,7 +306,6 @@
   },
   "footer": {
     "tagline": "Ein Hafen des Friedens im Herzen der Normandie",
-    "quick_links": "Schnelllinks",
     "contact": "Kontakt",
     "social": "Folgen Sie Uns",
     "copyright": "© 2024 Marianne Cottage. Alle Rechte vorbehalten."

--- a/messages/en.json
+++ b/messages/en.json
@@ -306,7 +306,6 @@
   },
   "footer": {
     "tagline": "A haven of peace in the heart of Normandy",
-    "quick_links": "Quick Links",
     "contact": "Contact",
     "social": "Follow Us",
     "copyright": "© 2024 Marianne Cottage. All rights reserved."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -306,7 +306,6 @@
   },
   "footer": {
     "tagline": "Un havre de paix au cœur de la Normandie",
-    "quick_links": "Liens Rapides",
     "contact": "Contact",
     "social": "Nous Suivre",
     "copyright": "© 2024 Marianne Cottage. Tous droits réservés."

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { localePath, t } from '$lib/i18n';
+	import { t } from '$lib/i18n';
 	import type { Messages, Locale } from '$lib/i18n';
 
 	interface Props {
@@ -8,14 +8,6 @@
 	}
 
 	let { lang, messages }: Props = $props();
-
-	const quickLinks = [
-		{ label: t(messages, 'nav.home'), href: '/' },
-		{ label: t(messages, 'nav.rooms'), href: '/rooms' },
-		{ label: t(messages, 'nav.gallery'), href: '/gallery' },
-		{ label: t(messages, 'nav.explore'), href: '/explore' },
-		{ label: t(messages, 'nav.contact'), href: '/contact' }
-	];
 </script>
 
 <footer class="footer">
@@ -24,20 +16,6 @@
 			<div>
 				<h3 class="footer-brand">Marianne Cottage</h3>
 				<p class="footer-tagline">{t(messages, 'footer.tagline')}</p>
-			</div>
-
-			<div>
-				<h4 class="footer-heading">{t(messages, 'footer.quick_links')}</h4>
-				<ul class="footer-links">
-					{#each quickLinks as link}
-						<li>
-							<a href={localePath(lang, link.href)}>{link.label}</a>
-						</li>
-					{/each}
-					<li>
-						<a href={localePath(lang, '/legal')}>{t(messages, 'nav.legal')}</a>
-					</li>
-				</ul>
 			</div>
 
 			<div>
@@ -90,7 +68,7 @@
 
 	@media (min-width: 840px) {
 		.footer-grid {
-			grid-template-columns: repeat(3, 1fr);
+			grid-template-columns: repeat(2, 1fr);
 		}
 	}
 
@@ -115,27 +93,7 @@
 		color: var(--color-footer-text);
 	}
 
-	.footer-links {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-	}
-
-	.footer-links a {
-		color: var(--color-footer-accent);
-		text-decoration: none;
-		font-size: 0.875rem;
-		transition: color 0.2s ease;
-	}
-
-	.footer-links a:hover {
-		color: white;
-	}
-
-	.footer-contact {
+.footer-contact {
 		font-size: 0.875rem;
 		color: var(--color-footer-accent);
 		display: flex;


### PR DESCRIPTION
## Summary
- Removed Quick Links section from footer (nav links, heading, styles)
- Updated footer grid from 3 columns to 2 (brand + contact)
- Removed `quick_links` translation key from en/fr/de message files

## Test plan
- [x] All 72 tests pass
- [ ] Visual check: footer renders cleanly with 2-column layout

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)