### PR TITLE
Add GitHub issue link to footer (#7)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -309,7 +309,8 @@
     "quick_links": "Schnelllinks",
     "contact": "Kontakt",
     "social": "Folgen Sie Uns",
-    "copyright": "© 2024 Marianne Cottage. Alle Rechte vorbehalten."
+    "copyright": "© 2024 Marianne Cottage. Alle Rechte vorbehalten.",
+    "report_issue": "Website-Problem melden"
   },
   "a11y": {
     "skip_to_content": "Zum Hauptinhalt springen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -309,7 +309,8 @@
     "quick_links": "Quick Links",
     "contact": "Contact",
     "social": "Follow Us",
-    "copyright": "© 2024 Marianne Cottage. All rights reserved."
+    "copyright": "© 2024 Marianne Cottage. All rights reserved.",
+    "report_issue": "Report a website issue"
   },
   "a11y": {
     "skip_to_content": "Skip to main content",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -309,7 +309,8 @@
     "quick_links": "Liens Rapides",
     "contact": "Contact",
     "social": "Nous Suivre",
-    "copyright": "© 2024 Marianne Cottage. Tous droits réservés."
+    "copyright": "© 2024 Marianne Cottage. Tous droits réservés.",
+    "report_issue": "Signaler un problème"
   },
   "a11y": {
     "skip_to_content": "Aller au contenu principal",

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -52,6 +52,9 @@
 
 		<div class="footer-bottom">
 			<p>{t(messages, 'footer.copyright')}</p>
+			<a href="https://github.com/Galifrey1965/Mariannecottage/issues/new" target="_blank" rel="noopener" class="report-issue">
+				{t(messages, 'footer.report_issue')}
+			</a>
 		</div>
 	</div>
 </footer>
@@ -157,5 +160,20 @@
 		font-size: 0.875rem;
 		color: var(--color-footer-accent);
 		margin: 0;
+	}
+
+	.report-issue {
+		display: inline-block;
+		margin-top: 0.75rem;
+		font-size: 0.75rem;
+		color: var(--color-footer-accent);
+		text-decoration: none;
+		opacity: 0.7;
+		transition: opacity 0.2s ease;
+	}
+
+	.report-issue:hover {
+		opacity: 1;
+		color: white;
 	}
 </style>


### PR DESCRIPTION
## Summary
- Added "Report a website issue" link in footer-bottom area linking to GitHub new issue page
- Styled subtly (small, muted) so it doesn't distract from main content
- Added translations for en/fr/de

## Test plan
- [x] All 72 tests pass
- [ ] Visual: link appears below copyright, opens GitHub issues/new in new tab

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)