### PR TITLE
Fix FAB button alignment in social links (#5)

### DIFF
--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -110,7 +110,7 @@
 	.directions-box { padding: 1rem; background: var(--color-cream); border-left: 4px solid var(--color-sage); border-radius: 4px; }
 	.directions-heading { font-weight: 600; color: var(--color-brown); margin: 0 0 0.5rem; }
 	.directions-text { font-size: 0.875rem; color: var(--color-text-muted); margin: 0; }
-	.social-links { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+	.social-links { display: flex; flex-wrap: nowrap; gap: 0.75rem; align-items: center; }
 	.fab-link {
 		display: inline-flex;
 		align-items: center;
@@ -123,6 +123,7 @@
 		font-weight: 600;
 		font-size: 0.875rem;
 		text-decoration: none;
+		white-space: nowrap;
 		box-shadow: var(--md-elevation-shadow-1);
 		transition: box-shadow 0.2s, transform 0.2s;
 	}


### PR DESCRIPTION
## Summary
- Changed `.social-links` from `flex-wrap: wrap` to `flex-wrap: nowrap` so all FAB buttons stay on one line
- Added `white-space: nowrap` to `.fab-link` to prevent text wrapping inside buttons

## Test plan
- [x] All 72 tests pass
- [ ] Visual: Booking.com, TripAdvisor, Facebook buttons all on same row

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)