### PR TITLE
Add website links and locale-aware distances to explore cards (#14)

### DIFF
--- a/src/lib/components/AttractionCard.svelte
+++ b/src/lib/components/AttractionCard.svelte
@@ -5,13 +5,16 @@
 		distance: string;
 		description: string;
 		category: string;
+		url?: string;
 	}
 
-	let { image, title, distance, description, category }: Props = $props();
+	let { image, title, distance, description, category, url }: Props = $props();
 </script>
 
-<div class="card">
-	<img src={image} alt={title} class="card-image" />
+<div class="card" title={title}>
+	<div class="card-image-wrapper">
+		<img src={image} alt={title} class="card-image" />
+	</div>
 	<div class="card-body">
 		<div class="card-header">
 			<h3 class="card-title">{title}</h3>
@@ -19,17 +22,38 @@
 		</div>
 		<p class="card-category">{category}</p>
 		<p class="card-text">{description}</p>
+		{#if url}
+			<a href={url} target="_blank" rel="noopener" class="card-link">
+				<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>
+				<span>{title}</span>
+			</a>
+		{/if}
 	</div>
 </div>
 
 <style>
 	.card { background: var(--md-sys-color-surface-container-lowest); border-radius: var(--md-shape-corner-medium); box-shadow: var(--md-elevation-shadow-1); overflow: hidden; transition: box-shadow 0.2s ease; }
 	.card:hover { box-shadow: var(--md-elevation-shadow-3); }
-	.card-image { width: 100%; height: 10rem; object-fit: cover; }
+	.card-image-wrapper { position: relative; overflow: hidden; }
+	.card-image { width: 100%; height: 10rem; object-fit: cover; transition: transform 0.3s ease; }
+	.card:hover .card-image { transform: scale(1.05); }
 	.card-body { padding: 1rem; }
 	.card-header { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 0.5rem; }
 	.card-title { font-family: 'Lora', serif; font-weight: 600; color: var(--color-brown); margin: 0; }
 	.distance-badge { font-size: 0.75rem; background: var(--color-cream); color: var(--color-brown); padding: 0.25rem 0.5rem; border-radius: 4px; white-space: nowrap; margin-left: 0.5rem; }
 	.card-category { font-size: 0.75rem; color: var(--color-text-muted); font-weight: 500; text-transform: uppercase; margin: 0 0 0.5rem; }
 	.card-text { font-size: 0.875rem; color: var(--color-text-muted); margin: 0; }
+	.card-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		margin-top: 0.75rem;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--color-sage);
+		text-decoration: none;
+		transition: color 0.2s ease;
+	}
+	.card-link:hover { color: var(--color-sage-hover); text-decoration: underline; }
+	.card-link svg { flex-shrink: 0; }
 </style>

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -5,7 +5,16 @@
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
-	const { messages } = data;
+	const { lang, messages } = data;
+
+	/** Format distance: km for fr/de, miles for en */
+	const dist = (km: number) => {
+		if (lang === 'en') {
+			const mi = Math.round(km * 0.621371);
+			return `${mi} mi`;
+		}
+		return `${km} km`;
+	};
 
 	const mapMarkers = [
 		{ lat: 49.1264, lng: -1.0986, title: 'Marianne Cottage', description: 'Your base in Normandy', type: 'cottage' as const },
@@ -23,23 +32,23 @@
 		{
 			category: 'ww2',
 			items: [
-				{ image: '/images/omaha-beach.jpg', title: t(messages, 'explore.omaha_beach'), distance: '29 km', description: t(messages, 'explore.omaha_desc') },
-				{ image: '/images/la-cambe-cemetery.jpg', title: t(messages, 'explore.la_cambe'), distance: '26 km', description: t(messages, 'explore.la_cambe_desc') },
-				{ image: '/images/overlord-museum.jpg', title: t(messages, 'explore.overlord'), distance: '29 km', description: t(messages, 'explore.overlord_desc') }
+				{ image: '/images/omaha-beach.jpg', title: t(messages, 'explore.omaha_beach'), distance: dist(29), description: t(messages, 'explore.omaha_desc'), url: 'https://www.musee-memorial-omaha.com/en/' },
+				{ image: '/images/la-cambe-cemetery.jpg', title: t(messages, 'explore.la_cambe'), distance: dist(26), description: t(messages, 'explore.la_cambe_desc'), url: 'https://kriegsgraeberstaetten.volksbund.de/en/friedhof/la-cambe' },
+				{ image: '/images/overlord-museum.jpg', title: t(messages, 'explore.overlord'), distance: dist(29), description: t(messages, 'explore.overlord_desc'), url: 'https://www.overlordmuseum.com/en/' }
 			]
 		},
 		{
 			category: 'nature',
 			items: [
-				{ image: '/images/cerisy-abbey.jpg', title: t(messages, 'explore.cerisy'), distance: '5 km', description: t(messages, 'explore.cerisy_desc') },
-				{ image: '/images/haras-saint-lo.jpg', title: t(messages, 'explore.haras'), distance: '13 km', description: t(messages, 'explore.haras_desc') }
+				{ image: '/images/cerisy-abbey.jpg', title: t(messages, 'explore.cerisy'), distance: dist(5), description: t(messages, 'explore.cerisy_desc'), url: 'https://www.abbaye-cerisy.fr/' },
+				{ image: '/images/haras-saint-lo.jpg', title: t(messages, 'explore.haras'), distance: dist(13), description: t(messages, 'explore.haras_desc'), url: 'https://www.polehippiquestlo.fr/' }
 			]
 		},
 		{
 			category: 'towns',
 			items: [
-				{ image: '/images/saint-lo.jpg', title: t(messages, 'explore.saintlo'), distance: '13 km', description: t(messages, 'explore.saintlo_desc') },
-				{ image: '/images/bayeux-cathedral.jpg', title: t(messages, 'explore.bayeux'), distance: '30 km', description: t(messages, 'explore.bayeux_desc') }
+				{ image: '/images/saint-lo.jpg', title: t(messages, 'explore.saintlo'), distance: dist(13), description: t(messages, 'explore.saintlo_desc'), url: 'https://saintlo-tourisme.com/' },
+				{ image: '/images/bayeux-cathedral.jpg', title: t(messages, 'explore.bayeux'), distance: dist(30), description: t(messages, 'explore.bayeux_desc'), url: 'https://www.bayeux.fr/en' }
 			]
 		}
 	];
@@ -77,6 +86,7 @@
 							distance={item.distance}
 							description={item.description}
 							category={category.category}
+							url={item.url}
 						/>
 					{/each}
 				</div>


### PR DESCRIPTION
## Summary
- Added official website links to all attraction cards (opens in new tab with external link icon)
- Distances are now locale-aware: miles for `en`, km for `fr`/`de`
- Card images zoom slightly on hover for visual feedback
- Card `title` attribute provides tooltip on hover

## Links added
- Omaha Beach → musee-memorial-omaha.com
- La Cambe Cemetery → volksbund.de
- Overlord Museum → overlordmuseum.com
- Cerisy Abbey → abbaye-cerisy.fr
- Haras National → polehippiquestlo.fr
- Saint-Lô → saintlo-tourisme.com
- Bayeux → bayeux.fr

## Test plan
- [x] All 72 tests pass
- [ ] Visual: links render on cards, distances show miles/km by locale

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)